### PR TITLE
Save graph buttons added

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -89,14 +89,14 @@ export const App = () => {
     }
     // If no graph is selected, show the current plot (if exists)
     return {
-      data: plot ? [plot] : [],
+      data: data,
       layout: { width: width, height: height },
     };
-  }, [currentGraphIndex, savedGraphs, plot]);
+  }, [currentGraphIndex, savedGraphs, plot,data]);
 
   useEffect(() => {
     if (!plot) return;
-    if (hide) {
+    if (hide ) {
       setData(data.filter((x) => x !== plot));
     } else if (!data.includes(plot)) {
       setData([plot]);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -47,6 +47,9 @@ export const App = () => {
   const hideIcon = useMemo(() => (hide ? faEyeSlash : faEye), [hide]);
   const hideColor = useMemo(() => (hide ? "grey" : "black"), [hide]);
 
+  const [savedGraphs, setSavedGraphs] = useState<Plotly.Data[]>([]); // Array of saved graphs
+  const [currentGraphIndex, setCurrentGraphIndex] = useState<number | null>(null); // Index of the currently selected graph
+
   const [lineColor, setLineColor] = useState<string>(ColorSwatches[0]);
 
   const iconColor = useMemo(() => getSecondaryColor(lineColor), [lineColor]);
@@ -55,6 +58,14 @@ export const App = () => {
     string | undefined
   >();
   const [customFunction, setCustomFunction] = useState<Function | undefined>();
+
+  // Function to save the current plot
+  const savePlot = () => {
+    if (plot) {
+      setSavedGraphs((prevGraphs) => [...prevGraphs, plot]);
+      console.log("Plot added to savedGraphs:", plot);
+    }
+  };
 
   const plot: Plotly.Data | undefined = useMemo(
     () =>
@@ -69,13 +80,19 @@ export const App = () => {
 
   const [data, setData] = useState<Partial<PlotData>[]>(plot ? [plot] : []);
 
-  const plotParams: PlotParams = useMemo(
-    () => ({
-      data: data,
-      layout: { width: width, height: height },
-    }),
-    [data, height, width]
-  );
+  const plotParams = useMemo(() => {
+    if (currentGraphIndex !== null && savedGraphs[currentGraphIndex]) {
+      return {
+        data: [savedGraphs[currentGraphIndex]], // Show the selected saved graph
+        layout: { width: 500, height: 500 },
+      };
+    }
+    // If no graph is selected, show the current plot (if exists)
+    return {
+      data: plot ? [plot] : [],
+      layout: { width: 500, height: 500 },
+    };
+  }, [currentGraphIndex, savedGraphs, plot]);
 
   useEffect(() => {
     if (!plot) return;
@@ -130,12 +147,28 @@ export const App = () => {
                 <FontAwesomeIcon icon={hideIcon} color="white" />
               </Button>
               <TextInput
+              
                 w="calc(100% - 96px)"
                 value={functionInputString}
                 onChange={(event) =>
                   setFunctionInputString(event.currentTarget.value)
                 }
               />
+              <Button
+              style={{
+                width: 80,
+              }}
+  onClick={() => {
+    if (plot) {
+      setSavedGraphs((prevGraphs) => [...prevGraphs, plot]);
+      console.log("Plot added to savedGraphs:", plot);
+    }
+  }}
+>
+  Save
+</Button>
+
+  
             </Group>
             {showColorSwatch && (
               <ColorPicker
@@ -146,11 +179,35 @@ export const App = () => {
                 w="100%"
               />
             )}
+              <div style ={{
+            
+          }}>
+      {savedGraphs.map((_, index) => (
+        <Button style={{
+        marginTop: 20,
+        marginBottom: 0,
+        marginRight: 20,
+        marginLeft: 30,
+      width: 180,
+      backgroundColor: currentGraphIndex === index ? "purple" : "",}}
+          key={index}
+          onClick={() => {
+            // Toggle between showing and hiding the graph
+            setCurrentGraphIndex(currentGraphIndex === index ? null : index);
+          }} // Set the current graph index to display it
+        >
+          Show Saved Graph {index + 1}
+        </Button>
+      ))}
+    </div>
             {/* <Text>{debugPrintFunction}</Text> */}
           </Paper>
         </Stack>
         <Plot {...plotParams} />
       </Group>
+    
     </Stack>
+    
+    
   );
-};
+}; 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -84,13 +84,13 @@ export const App = () => {
     if (currentGraphIndex !== null && savedGraphs[currentGraphIndex]) {
       return {
         data: [savedGraphs[currentGraphIndex]], // Show the selected saved graph
-        layout: { width: 500, height: 500 },
+        layout: { width: width, height: height },
       };
     }
     // If no graph is selected, show the current plot (if exists)
     return {
       data: plot ? [plot] : [],
-      layout: { width: 500, height: 500 },
+      layout: { width: width, height: height },
     };
   }, [currentGraphIndex, savedGraphs, plot]);
 


### PR DESCRIPTION
Users can now save a graph, which will generate a button for each graph saved, that when clicked will show the related graph. 